### PR TITLE
Enable PROXY protocol for RU Xray bridge client IP in access logs

### DIFF
--- a/roles/monitoring/templates/dashboards/xray-users-traffic.json.j2
+++ b/roles/monitoring/templates/dashboards/xray-users-traffic.json.j2
@@ -246,12 +246,13 @@
       "collapsed": false,
       "gridPos": {"h": 1, "w": 24, "x": 0, "y": 42},
       "id": 30,
-      "title": "Карта локаций пользователей",
+      "title": "Карта локаций пользователей (ingress RU)",
       "type": "row"
     },
 
     {
       "datasource": {"type": "prometheus", "uid": "{{ grafana_prometheus_datasource_uid }}"},
+      "description": "Геолокация по IP из access.log xray-bridge на RU (клиенты приходят на RU, дальше transparent stream на EU). Метрика job=xray-bridge-stats — не EU xray-stats.",
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "palette-classic"},
@@ -291,7 +292,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "{{ grafana_prometheus_datasource_uid }}"},
           "editorMode": "code",
-          "expr": "xray_user_last_country",
+          "expr": "xray_user_last_country{job=\"xray-bridge-stats\"}",
           "instant": true,
           "queryType": "instant",
           "range": false,
@@ -318,7 +319,7 @@
           }
         }
       ],
-      "title": "Карта локаций пользователей",
+      "title": "Карта локаций пользователей (RU ingress)",
       "type": "geomap"
     }
 
@@ -332,6 +333,6 @@
   "timezone": "browser",
   "title": "Xray — per-user upload / download",
   "uid": "raven-xray-users-traffic",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }

--- a/roles/relay/templates/nginx/stream.conf.j2
+++ b/roles/relay/templates/nginx/stream.conf.j2
@@ -15,6 +15,10 @@
 {% endif %}
 #   everything else (VPN)  → EU server ({{ relay_upstream_host }}:{{ relay_upstream_port }})
 #
+# PROXY protocol: only on upstreams to local Xray (127.0.0.1). Real client IP in
+# access.log → xray-stats-exporter geo / Grafana map. Do NOT add proxy_protocol
+# to eu_vpn — EU expects raw TCP without PROXY.
+#
 # This file is included inside stream {} block in nginx.conf
 
 {% if relay_stream_enabled %}
@@ -39,25 +43,25 @@ upstream local_https {
 
 {% if relay_bridge_enabled | default(false) and relay_bridge_sni != '' %}
 upstream xray_bridge {
-    server 127.0.0.1:{{ relay_bridge_port }};
+    server 127.0.0.1:{{ relay_bridge_port }} proxy_protocol;
 }
 
 {% endif %}
 {% if relay_transparent_enabled | default(false) %}
 upstream xray_bridge_reality {
-    server 127.0.0.1:{{ relay_transparent_reality_port }};
+    server 127.0.0.1:{{ relay_transparent_reality_port }} proxy_protocol;
 }
 
 upstream xray_bridge_xhttp {
-    server 127.0.0.1:{{ relay_transparent_xhttp_port }};
+    server 127.0.0.1:{{ relay_transparent_xhttp_port }} proxy_protocol;
 }
 
 upstream xray_bridge_reality_v2 {
-    server 127.0.0.1:{{ relay_transparent_reality_v2_port }};
+    server 127.0.0.1:{{ relay_transparent_reality_v2_port }} proxy_protocol;
 }
 
 upstream xray_bridge_xhttp_v2 {
-    server 127.0.0.1:{{ relay_transparent_xhttp_v2_port }};
+    server 127.0.0.1:{{ relay_transparent_xhttp_v2_port }} proxy_protocol;
 }
 
 {% endif %}

--- a/roles/xray_bridge/templates/conf/inbounds/200-in-vless-reality.json.j2
+++ b/roles/xray_bridge/templates/conf/inbounds/200-in-vless-reality.json.j2
@@ -28,6 +28,9 @@
       },
       "streamSettings": {
         "network": "tcp",
+        "sockopt": {
+          "acceptProxyProtocol": true
+        },
         "security": "reality",
         "realitySettings": {
           "show": false,

--- a/roles/xray_bridge/templates/conf/inbounds/205-in-transparent.json.j2
+++ b/roles/xray_bridge/templates/conf/inbounds/205-in-transparent.json.j2
@@ -31,6 +31,9 @@
       },
       "streamSettings": {
         "network": "tcp",
+        "sockopt": {
+          "acceptProxyProtocol": true
+        },
         "security": "reality",
         "realitySettings": {
           "show": false,
@@ -93,6 +96,9 @@
       },
       "streamSettings": {
         "network": "{{ xray_xhttp.network }}",
+        "sockopt": {
+          "acceptProxyProtocol": true
+        },
         "security": "reality",
         "realitySettings": {
           "show": false,
@@ -162,6 +168,9 @@
       },
       "streamSettings": {
         "network": "tcp",
+        "sockopt": {
+          "acceptProxyProtocol": true
+        },
         "security": "reality",
         "realitySettings": {
           "show": false,
@@ -224,6 +233,9 @@
       },
       "streamSettings": {
         "network": "{{ xray_v2_xhttp.network }}",
+        "sockopt": {
+          "acceptProxyProtocol": true
+        },
         "security": "reality",
         "realitySettings": {
           "show": false,


### PR DESCRIPTION
nginx stream sends PROXY only to local Xray upstreams (not EU relay). Bridge inbounds set sockopt.acceptProxyProtocol for real IPs in access.log so xray-stats-exporter geo metrics and Grafana map work.

Dashboard: scope geomap to job=xray-bridge-stats, clarify RU ingress in titles.
Made-with: Cursor