### PR TITLE
fix: correct inventory path in nginx_frontend and xray_bridge playbooks

### DIFF
--- a/roles/role_nginx_frontend.yml
+++ b/roles/role_nginx_frontend.yml
@@ -1,7 +1,7 @@
 ---
 # nginx frontend playbook — EU VPS
 # Usage:
-#   ansible-playbook roles/role_nginx_frontend.yml -i roles/nginx_frontend/inventory.ini \
+#   ansible-playbook roles/role_nginx_frontend.yml -i roles/hosts.yml \
 #     --vault-password-file vault_password.txt
 #
 # Tags:

--- a/roles/role_xray_bridge.yml
+++ b/roles/role_xray_bridge.yml
@@ -9,12 +9,12 @@
 #
 # Deployment:
 #   ansible-playbook roles/role_xray_bridge.yml \
-#     -i roles/relay/inventory.ini \
+#     -i roles/hosts.yml \
 #     --vault-password-file vault_password.txt
 #
 # After deploying the bridge, update relay role to route bridge SNI:
 #   Set relay_bridge_enabled=true and relay_bridge_sni in relay secrets.yml
-#   ansible-playbook roles/role_relay.yml -i roles/relay/inventory.ini \
+#   ansible-playbook roles/role_relay.yml -i roles/hosts.yml \
 #     --vault-password-file vault_password.txt --tags relay_stream
 #
 # Tags:


### PR DESCRIPTION
roles/nginx_frontend/inventory.ini and roles/relay/inventory.ini never existed; both playbooks target hosts already defined in roles/hosts.yml.