### PR TITLE
fix: align nginx_frontend playbook hosts with inventory.ini convention

### DIFF
--- a/roles/role_nginx_frontend.yml
+++ b/roles/role_nginx_frontend.yml
@@ -1,7 +1,7 @@
 ---
 # nginx frontend playbook — EU VPS
 # Usage:
-#   ansible-playbook roles/role_nginx_frontend.yml -i roles/hosts.yml \
+#   ansible-playbook roles/role_nginx_frontend.yml -i roles/nginx_frontend/inventory.ini \
 #     --vault-password-file vault_password.txt
 #
 # Tags:
@@ -12,7 +12,7 @@
 #   nginx_frontend_stream   — deploy TCP stream relay for VLESS Reality
 
 - name: Configure nginx frontend
-  hosts: vm_my_srv
+  hosts: vpn
   become: true
 
   vars_files:


### PR DESCRIPTION
README documents the host as 'vpn' in inventory.ini, but the playbook targeted 'vm_my_srv', causing 'no hosts matched' on every run. Also fix the usage comment to reference the correct inventory path.