### PR TITLE
fix: nginx http2 directive compatibility with < 1.25.1

### DIFF
--- a/roles/nginx_frontend/tasks/nginx_ssl.yml
+++ b/roles/nginx_frontend/tasks/nginx_ssl.yml
@@ -1,4 +1,15 @@
 ---
+- name: Nginx frontend | Detect nginx version for http2 directive
+  ansible.builtin.command: nginx -v
+  register: _nginx_version_output
+  changed_when: false
+
+- name: Nginx frontend | Set http2 directive fact
+  ansible.builtin.set_fact:
+    _nginx_has_http2_directive: >-
+      {{ (_nginx_version_output.stderr | regex_search('nginx/(\d+\.\d+\.\d+)', '\1') | first | default('0.0.0'))
+         is version('1.25.1', '>=') }}
+
 - name: Nginx frontend | Deploy HTTPS config
   ansible.builtin.template:
     src: nginx/https.conf.j2

--- a/roles/nginx_frontend/templates/nginx/https.conf.j2
+++ b/roles/nginx_frontend/templates/nginx/https.conf.j2
@@ -12,8 +12,10 @@
 
 # ── HTTPS ─────────────────────────────────────────────────────────────────────
 server {
-    listen {{ nginx_frontend_listen_port }} ssl;
+    listen {{ nginx_frontend_listen_port }} ssl{{ '' if _nginx_has_http2_directive else ' http2' }};
+{% if _nginx_has_http2_directive %}
     http2 on;
+{% endif %}
     server_name _;
 
     ssl_certificate     /etc/nginx/ssl/nginx-frontend.crt;

--- a/roles/relay/tasks/nginx_ssl.yml
+++ b/roles/relay/tasks/nginx_ssl.yml
@@ -1,6 +1,17 @@
 ---
 # Full HTTPS config with proxy_pass — deployed after certbot
 
+- name: Relay | Detect nginx version for http2 directive
+  ansible.builtin.command: nginx -v
+  register: _nginx_version_output
+  changed_when: false
+
+- name: Relay | Set http2 directive fact
+  ansible.builtin.set_fact:
+    _nginx_has_http2_directive: >-
+      {{ (_nginx_version_output.stderr | regex_search('nginx/(\d+\.\d+\.\d+)', '\1') | first | default('0.0.0'))
+         is version('1.25.1', '>=') }}
+
 - name: Relay | Deploy HTTPS nginx config
   ansible.builtin.template:
     src: nginx/https.conf.j2

--- a/roles/relay/templates/nginx/https.conf.j2
+++ b/roles/relay/templates/nginx/https.conf.j2
@@ -6,8 +6,10 @@
 
 # ── {{ relay_domain }} — stub site ──────────────────────────────────────────────────
 server {
-    listen {{ relay_https_port }} ssl;
+    listen {{ relay_https_port }} ssl{{ '' if _nginx_has_http2_directive else ' http2' }};
+{% if _nginx_has_http2_directive %}
     http2 on;
+{% endif %}
     server_name {{ relay_domain }};
 
     ssl_certificate     /etc/letsencrypt/live/{{ relay_domain }}/fullchain.pem;
@@ -25,8 +27,10 @@ server {
 
 # ── {{ relay_sub_my }} — Raven-subscribe relay ───────────────────────────────────
 server {
-    listen {{ relay_https_port }} ssl;
+    listen {{ relay_https_port }} ssl{{ '' if _nginx_has_http2_directive else ' http2' }};
+{% if _nginx_has_http2_directive %}
     http2 on;
+{% endif %}
     server_name {{ relay_sub_my }};
 
     ssl_certificate     /etc/letsencrypt/live/{{ relay_domain }}/fullchain.pem;


### PR DESCRIPTION
## Summary
- Auto-detect nginx version at deploy time and render the correct HTTP/2 syntax
- nginx >= 1.25.1: standalone `http2 on;` directive (current behavior)
- nginx < 1.25.1: `listen ... ssl http2;` (old syntax)
- Fixes `unknown directive "http2"` error on older nginx versions (Debian 11, Ubuntu 20.04 stock packages)

## Affected roles
- `nginx_frontend` — HTTPS config template + deploy task
- `relay` — HTTPS config template + deploy task

## Test plan
- [ ] Deploy on server with nginx >= 1.25.1 (existing infra — no regression)
- [ ] Verify on server with nginx < 1.25.1 (user-reported issue)