### PR TITLE
fix: install libnginx-mod-stream, improve secrets validation hints

### DIFF
--- a/roles/nginx_frontend/tasks/install.yml
+++ b/roles/nginx_frontend/tasks/install.yml
@@ -3,6 +3,7 @@
   ansible.builtin.apt:
     name:
       - nginx
+      - libnginx-mod-stream
       - certbot
       - python3-certbot-nginx
     state: present

--- a/roles/raven_subscribe/tasks/main.yml
+++ b/roles/raven_subscribe/tasks/main.yml
@@ -8,7 +8,10 @@
       - raven_subscribe_server_host != ''
     fail_msg: >-
       raven_subscribe_admin_token and raven_subscribe_server_host must be set in secrets.yml.
-      Generate a strong token: openssl rand -hex 32
+      Copy the example file and fill in your values:
+        cp roles/raven_subscribe/defaults/secrets.yml.example roles/raven_subscribe/defaults/secrets.yml
+        # edit the file, then encrypt:
+        ansible-vault encrypt roles/raven_subscribe/defaults/secrets.yml --vault-password-file vault_password.txt
     success_msg: "Raven-subscribe vars are valid"
 
 - name: Raven-subscribe | Get latest release info

--- a/roles/relay/tasks/install.yml
+++ b/roles/relay/tasks/install.yml
@@ -3,6 +3,7 @@
   ansible.builtin.apt:
     name:
       - nginx
+      - libnginx-mod-stream
       - certbot
       - python3-certbot-nginx
     state: present


### PR DESCRIPTION
## Summary
- Add `libnginx-mod-stream` to nginx install tasks in `nginx_frontend` and `relay` roles — fixes `unknown directive "stream"` on fresh Debian/Ubuntu where the stream module is not bundled with the base `nginx` package
- Improve `raven_subscribe` validation error message to show exact copy+encrypt commands for creating `secrets.yml` from the example file

## Fixes
- `unknown directive "stream" in /etc/nginx/nginx.conf` on fresh install
- Confusing validation error when `secrets.yml` was never created from the `.example` file

## User action for existing broken installs
```bash
# For stream directive error:
sudo apt install libnginx-mod-stream
sudo systemctl start nginx

# For raven_subscribe secrets error:
cp roles/raven_subscribe/defaults/secrets.yml.example roles/raven_subscribe/defaults/secrets.yml
# fill in admin_token and server_host, then:
ansible-vault encrypt roles/raven_subscribe/defaults/secrets.yml --vault-password-file vault_password.txt
```