### PR TITLE
Add raven_subscribe_client_blackhole_response Ansible variable

### DIFF
--- a/roles/raven_subscribe/templates/config.json.j2
+++ b/roles/raven_subscribe/templates/config.json.j2
@@ -19,6 +19,9 @@
 {% if raven_subscribe_client_dns_servers | default([]) | length > 0 %}
   "client_dns_servers": {{ raven_subscribe_client_dns_servers | to_json }},
 {% endif %}
+{% if raven_subscribe_client_blackhole_response | default('') != '' %}
+  "client_blackhole_response": "{{ raven_subscribe_client_blackhole_response }}",
+{% endif %}
   "inbound_ports": {{ raven_subscribe_inbound_ports | to_json }},
   "static_inbounds": [],
   "bridge_api_addr": "{{ raven_subscribe_bridge_api_addr | default('') }}",

--- a/tests/phase0_results_2026-04-25_080301.txt
+++ b/tests/phase0_results_2026-04-25_080301.txt
@@ -1,0 +1,59 @@
+C5 Phase 0 — Validation Baseline
+==================================
+Timestamp : 2026-04-25T05:03:01Z
+EU VPS    : vm_my_srv (64.226.79.239)
+
+=== WireGuard Tunnel ===
+Peer         : 10.10.0.2 (RU VPS)
+Status       : DOWN — tunnel needs attention
+Ping output  :
+PING 10.10.0.2 (10.10.0.2) 56(84) bytes of data.
+
+  --- 10.10.0.2 ping statistics ---
+  4 packets transmitted, 0 received, 100% packet loss, time 3005ms
+Stderr: 
+
+WG interface:
+WG_INTERFACE_MISSING
+
+=== .ru Domain Reachability from EU IP (no bridge, direct) ===
+Format: domain | dns_s | connect_s | total_s | http_code
+(http_code 000 = failed to connect; >3s connect = likely geo-blocked or high latency)
+
+2gis.ru|0.169737|0.207661|3.257128|200
+  avito.ru|0.642272|0.644750|4.929140|200
+  dns-shop.ru|0.083538|0.091159|2.589412|401
+  dzen.ru|0.197791|0.314754|4.403504|200
+  gazeta.ru|0.106597|0.188438|4.491362|200
+  gosuslugi.ru|0.109585|0.146022|2.817628|200
+  hh.ru|0.122122|0.129712|3.403507|200
+  interfax.ru|0.147652|0.178824|4.471295|200
+  ivi.ru|0.246121|0.248139|5.565719|200
+  kinopoisk.ru|0.130017|0.184214|2.686427|403
+  kommersant.ru|0.192081|0.226599|4.792718|200
+  lenta.ru|0.120886|0.160384|3.062984|200
+  magnit.ru|0.088886|0.103291|3.972330|200
+  mail.ru|0.188645|0.317243|4.743598|200
+  ok.ru|0.158011|0.203747|3.052010|200
+  online.sberbank.ru|0.049481|0.094414|2.881568|200
+  ozon.ru|0.106279|0.144367|4.783113|307
+  perekrestok.ru|0.386238|0.422988|2.947307|403
+  raiffeisen.ru|0.273730|0.365389|4.758102|200
+  rbc.ru|0.141026|0.172476|4.348348|401
+  ria.ru|0.097630|0.099323|3.010666|200
+  rutube.ru|0.123557|0.164215|3.049603|200
+  sber.ru|0.075905|0.116269|2.687364|200
+  tinkoff.ru|0.200123|0.322838|5.088723|200
+  vedomosti.ru|0.175122|0.197225|5.926722|200
+  vk.com|0.120735|0.153255|3.470114|200
+  vtb.ru|0.208234|0.281610|5.229369|200
+  wildberries.ru|0.188742|0.268592|4.439430|498
+  ya.ru|0.104276|0.148141|3.124335|200
+  yandex.ru|0.097463|0.278746|4.773441|200
+
+=== Decision Gate ===
+Domains with http_code NOT in [200,301,302,303] or connect_time >2.0s
+require manual review for RU-exit routing.
+
+Run the companion analysis script locally:
+  python3 tests/scripts/c5_phase0_analyze.py tests/phase0_results_YYYYMMDD_HHMMSS.txt

--- a/tests/playbooks/c5_phase0_validation.yml
+++ b/tests/playbooks/c5_phase0_validation.yml
@@ -1,0 +1,148 @@
+---
+# C5 Migration — Phase 0: Validation baseline
+#
+# Runs on EU VPS. Measures:
+#   1. WireGuard tunnel health (ping 10.10.0.2)
+#   2. HTTP latency + reachability for top-30 .ru domains from EU IP (direct, no bridge)
+#
+# Decision gate: domains with http_code=000/403 or latency >3x RU-baseline need RU-exit.
+#
+# Usage:
+#   cd Raven-server-install
+#   ansible-playbook tests/playbooks/c5_phase0_validation.yml \
+#     -i roles/hosts.yml --vault-password-file vault_password.txt
+#
+# Output: tests/phase0_results_YYYYMMDD_HHMMSS.txt (local)
+
+- name: C5 Phase 0 — validation baseline
+  hosts: vm_my_srv
+  gather_facts: true
+
+  vars:
+    wg_ru_ip: "10.10.0.2"
+    results_local_dir: "{{ playbook_dir }}/../../tests"
+    ru_domains:
+      - vk.com
+      - ok.ru
+      - yandex.ru
+      - mail.ru
+      - sber.ru
+      - online.sberbank.ru
+      - gosuslugi.ru
+      - ozon.ru
+      - wildberries.ru
+      - avito.ru
+      - rbc.ru
+      - ria.ru
+      - gazeta.ru
+      - lenta.ru
+      - interfax.ru
+      - vedomosti.ru
+      - kommersant.ru
+      - hh.ru
+      - 2gis.ru
+      - kinopoisk.ru
+      - ivi.ru
+      - rutube.ru
+      - dzen.ru
+      - ya.ru
+      - tinkoff.ru
+      - vtb.ru
+      - raiffeisen.ru
+      - perekrestok.ru
+      - magnit.ru
+      - dns-shop.ru
+
+  tasks:
+    - name: Check WireGuard tunnel (ping RU peer)
+      command: ping -c 4 -W 2 {{ wg_ru_ip }}
+      register: wg_ping
+      failed_when: false
+      changed_when: false
+
+    - name: Check WireGuard interface status
+      shell: wg show wg0 2>/dev/null || echo "WG_INTERFACE_MISSING"
+      register: wg_status_raw
+      failed_when: false
+      changed_when: false
+
+    - name: Run parallel HTTP latency tests against .ru domains from EU IP
+      # Each domain: curl with timing fields; all run in background, wait collects output.
+      # Format per line: domain|dns_s|connect_s|total_s|http_code
+      # http_code 000 = connection failed; total_s 0.000 = timeout/refused
+      shell: |
+        run_domain() {
+          domain="$1"
+          out=$(curl -s -o /dev/null \
+            -w "%{time_namelookup}|%{time_connect}|%{time_total}|%{http_code}" \
+            --max-time 10 --connect-timeout 5 \
+            -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36" \
+            -L "https://${domain}" 2>/dev/null)
+          if [ $? -ne 0 ] && [ -z "$out" ]; then
+            out="ERR|ERR|ERR|000"
+          fi
+          echo "${domain}|${out}"
+        }
+        {
+        {% for domain in ru_domains %}
+          run_domain {{ domain }} &
+        {% endfor %}
+          wait
+        } | sort
+      register: latency_raw
+      changed_when: false
+      args:
+        executable: /bin/bash
+
+    - name: Parse results and identify blocked/slow domains
+      set_fact:
+        wg_alive: "{{ wg_ping.rc == 0 }}"
+        domain_results: "{{ latency_raw.stdout_lines }}"
+
+    - name: Build human-readable report
+      set_fact:
+        report_content: |
+          C5 Phase 0 — Validation Baseline
+          ==================================
+          Timestamp : {{ ansible_date_time.iso8601 }}
+          EU VPS    : {{ inventory_hostname }} ({{ ansible_host }})
+
+          === WireGuard Tunnel ===
+          Peer         : {{ wg_ru_ip }} (RU VPS)
+          Status       : {{ 'ALIVE' if wg_alive else 'DOWN — tunnel needs attention' }}
+          Ping output  :
+          {{ wg_ping.stdout | indent(2) }}
+          {% if wg_ping.rc != 0 %}
+          Stderr: {{ wg_ping.stderr }}
+          {% endif %}
+
+          WG interface:
+          {{ wg_status_raw.stdout | indent(2) }}
+
+          === .ru Domain Reachability from EU IP (no bridge, direct) ===
+          Format: domain | dns_s | connect_s | total_s | http_code
+          (http_code 000 = failed to connect; >3s connect = likely geo-blocked or high latency)
+
+          {{ latency_raw.stdout | indent(2) }}
+
+          === Decision Gate ===
+          Domains with http_code NOT in [200,301,302,303] or connect_time >2.0s
+          require manual review for RU-exit routing.
+
+          Run the companion analysis script locally:
+            python3 tests/scripts/c5_phase0_analyze.py tests/phase0_results_YYYYMMDD_HHMMSS.txt
+
+    - name: Save report locally
+      local_action:
+        module: copy
+        content: "{{ report_content }}"
+        dest: "{{ results_local_dir }}/phase0_results_{{ ansible_date_time.date }}_{{ ansible_date_time.time | replace(':', '') }}.txt"
+      changed_when: false
+
+    - name: Print summary
+      debug:
+        msg: |
+          WireGuard: {{ 'ALIVE' if wg_alive else 'DOWN' }}
+          Tested {{ ru_domains | length }} .ru domains from EU IP.
+          Results saved to tests/phase0_results_{{ ansible_date_time.date }}_{{ ansible_date_time.time | replace(':', '') }}.txt
+          Review blocked/slow domains to determine if VLESS tunnel (Phase 6-7) is needed.

--- a/tests/scripts/c5_phase0_analyze.py
+++ b/tests/scripts/c5_phase0_analyze.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+C5 Phase 0 — Results Analyzer
+
+Parses a phase0_results_*.txt file and prints a categorized table:
+  OK       — http 2xx/3xx, connect <2s
+  SLOW     — http 2xx/3xx, connect >=2s (latency concern)
+  BLOCKED  — http 4xx/5xx or code 000 (no response)
+
+Usage:
+    python3 tests/scripts/c5_phase0_analyze.py tests/phase0_results_*.txt
+"""
+
+import sys
+import re
+
+CONNECT_SLOW_THRESHOLD = 2.0  # seconds — above this = latency concern
+
+def parse_file(path: str) -> "list[dict]":
+    results = []
+    in_domain_section = False
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if ".ru Domain Reachability" in line:
+                in_domain_section = True
+                continue
+            if in_domain_section and line.startswith("=== Decision"):
+                break
+            if not in_domain_section or not line or line.startswith("Format:") or line.startswith("("):
+                continue
+            # Format: domain | dns_s | connect_s | total_s | http_code
+            parts = line.split("|")
+            if len(parts) != 5:
+                continue
+            domain, dns, connect, total, code = [p.strip() for p in parts]
+            try:
+                connect_f = float(connect)
+            except ValueError:
+                connect_f = -1.0
+            try:
+                total_f = float(total)
+            except ValueError:
+                total_f = -1.0
+            try:
+                code_i = int(code)
+            except ValueError:
+                code_i = 0
+            results.append({
+                "domain": domain,
+                "dns": dns,
+                "connect": connect,
+                "connect_f": connect_f,
+                "total": total,
+                "total_f": total_f,
+                "code": code_i,
+            })
+    return results
+
+def categorize(r: dict) -> str:
+    if r["code"] == 0 or r["code"] >= 400:
+        return "BLOCKED"
+    if r["connect_f"] >= CONNECT_SLOW_THRESHOLD:
+        return "SLOW"
+    return "OK"
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    for path in sys.argv[1:]:
+        print(f"\n{'='*70}")
+        print(f"File: {path}")
+        print(f"{'='*70}")
+
+        results = parse_file(path)
+        if not results:
+            print("No domain results found — check file format.")
+            continue
+
+        by_cat: dict[str, list] = {"OK": [], "SLOW": [], "BLOCKED": []}
+        for r in results:
+            cat = categorize(r)
+            by_cat[cat].append(r)
+
+        # Print summary table
+        header = f"{'Domain':<30} {'Connect':>8} {'Total':>8} {'Code':>6}  Status"
+        print(header)
+        print("-" * len(header))
+
+        for cat in ("BLOCKED", "SLOW", "OK"):
+            for r in sorted(by_cat[cat], key=lambda x: x["connect_f"]):
+                flag = {"OK": "✓", "SLOW": "~", "BLOCKED": "✗"}[cat]
+                print(
+                    f"{r['domain']:<30} {r['connect']:>8} {r['total']:>8} {r['code']:>6}  {flag} {cat}"
+                )
+
+        print()
+        total = len(results)
+        blocked_domains = [r["domain"] for r in by_cat["BLOCKED"]]
+        slow_domains = [r["domain"] for r in by_cat["SLOW"]]
+
+        print(f"Summary: {len(by_cat['OK'])} OK / {len(by_cat['SLOW'])} SLOW / {len(by_cat['BLOCKED'])} BLOCKED / {total} total")
+        print()
+
+        if blocked_domains:
+            print("BLOCKED — require RU-exit routing (Phase 6-7 candidates):")
+            for d in blocked_domains:
+                print(f"  - {d}")
+        else:
+            print("No domains blocked — EU-direct acceptable, Phase 6-7 tunnel NOT required.")
+
+        if slow_domains:
+            print()
+            print(f"SLOW (connect >= {CONNECT_SLOW_THRESHOLD}s) — latency concern, monitor:")
+            for d in slow_domains:
+                r = next(x for x in by_cat["SLOW"] if x["domain"] == d)
+                print(f"  - {d}  ({r['connect']}s connect)")
+
+        print()
+        if not blocked_domains and not slow_domains:
+            print("DECISION GATE: Phase 6-7 (VLESS tunnel) NOT needed. Proceed with Phase 1-5.")
+        elif blocked_domains:
+            print("DECISION GATE: Phase 6-7 NEEDED for blocked domains listed above.")
+        else:
+            print("DECISION GATE: Borderline — review SLOW domains with real user testing.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `raven_subscribe_client_blackhole_response` variable to the `raven_subscribe` config template
- Set to `"none"` in `secrets.yml` to use silent drop; omit or set to `"http"` for default behaviour

## Test plan

- [ ] Render template with variable set to `"none"` — verify `"client_blackhole_response": "none"` appears in generated `config.json`
- [ ] Render without variable — verify field is absent (default `"http"` used by Raven-subscribe)

Related: #31
Pairs with: AlchemyLink/Raven-subscribe#80