### PR TITLE
feat(raven_dashboard): Telegram bot token in config template

### DIFF
--- a/roles/raven_dashboard/defaults/main.yml
+++ b/roles/raven_dashboard/defaults/main.yml
@@ -43,8 +43,9 @@ raven_dashboard_db_migrate_src: ""
 # raven_dashboard_local_frontend_tar: ""
 
 ##### Set these in secrets.yml (ansible-vault encrypted) #####
-# raven_dashboard_jwt_secret: ""           # openssl rand -hex 32 (min 32 chars)
-# raven_dashboard_raven_admin_token: ""    # same as raven_subscribe_admin_token
-# raven_dashboard_raven_origin_secret: "" # X-Origin-Secret for calls to Cloudflare-proxied Raven
+# raven_dashboard_jwt_secret: ""              # openssl rand -hex 32 (min 32 chars)
+# raven_dashboard_raven_admin_token: ""       # same as raven_subscribe_admin_token
+# raven_dashboard_raven_origin_secret: ""     # X-Origin-Secret for Cloudflare-proxied Raven
 # raven_dashboard_prometheus_user: ""
 # raven_dashboard_prometheus_password: ""
+# raven_dashboard_telegram_bot_token: ""      # optional — create via @BotFather; empty = bot disabled

--- a/roles/raven_dashboard/defaults/secrets.yml.example
+++ b/roles/raven_dashboard/defaults/secrets.yml.example
@@ -17,3 +17,7 @@ raven_dashboard_raven_origin_secret: ""
 # VictoriaMetrics basic auth credentials (must match monitoring role)
 raven_dashboard_prometheus_user: ""
 raven_dashboard_prometheus_password: ""
+
+# Telegram bot token (optional). Create via @BotFather.
+# Leave empty to disable the bot — dashboard works without it.
+raven_dashboard_telegram_bot_token: ""

--- a/roles/raven_dashboard/templates/config.json.j2
+++ b/roles/raven_dashboard/templates/config.json.j2
@@ -15,5 +15,7 @@
   "enable_websocket": {{ raven_dashboard_enable_websocket | lower }},
   "websocket_auth_enabled": {{ raven_dashboard_websocket_auth_enabled | lower }},
   "cors_allowed_origins": {{ raven_dashboard_cors_allowed_origins | to_json }},
-  "max_request_body_bytes": {{ raven_dashboard_max_request_body_bytes }}
+  "max_request_body_bytes": {{ raven_dashboard_max_request_body_bytes }}{% if raven_dashboard_telegram_bot_token | default('') %},
+  "telegram_bot_token": "{{ raven_dashboard_telegram_bot_token }}"{% endif %}
+
 }


### PR DESCRIPTION
## Summary

- `config.json.j2` — добавлен опциональный `telegram_bot_token` (через Jinja2 conditional, не попадает в JSON если пустой)
- `defaults/main.yml` — документирующий комментарий о переменной
- `defaults/secrets.yml.example` — пример записи с инструкцией

## Поведение шаблона

Если `raven_dashboard_telegram_bot_token` пустой (по умолчанию) — ключ в `config.json` не появляется, бот молча отключён.

Если задан — добавляется:
```json
"telegram_bot_token": "<токен>"
```

## Как применить

1. Создать бота через @BotFather, получить токен
2. Добавить в `roles/raven_dashboard/defaults/secrets.yml` (vault):
   ```
   raven_dashboard_telegram_bot_token: "1234567890:AAAA..."
   ```
3. Передеплоить роль:
   ```bash
   ansible-playbook roles/role_raven_dashboard.yml -i roles/hosts.yml --vault-password-file vault_password.txt
   ```

## Test plan

- [ ] Деплой с пустым токеном — `config.json` не содержит `telegram_bot_token`
- [ ] Деплой с токеном — `config.json` содержит поле, бот работает

🤖 Generated with [Claude Code](https://claude.com/claude-code)