### PR TITLE
monitoring: auto-download xray-stats-exporter from GitHub releases

### DIFF
--- a/roles/monitoring/defaults/main.yml
+++ b/roles/monitoring/defaults/main.yml
@@ -64,6 +64,12 @@ node_exporter_bin_dir: "/usr/local/bin"
 node_exporter_service_name: "node_exporter"
 
 # xray-stats-exporter (per-user traffic via StatsService gRPC)
+# Public GitHub repo — release workflow builds linux-amd64 / linux-arm64 /
+# darwin-amd64 / darwin-arm64. The role auto-resolves the binary URL and
+# downloads it; pin via xray_stats_exporter_version, or override the whole
+# fetch with -e xray_stats_exporter_local_binary=/path for a hand-built drop.
+xray_stats_exporter_github_repo: "AlchemyLink/xray-stats-exporter"
+xray_stats_exporter_version: "latest"
 xray_stats_exporter_listen: "127.0.0.1:9551"
 xray_stats_exporter_metrics_path: "/metrics"
 xray_stats_exporter_xray_endpoint: "127.0.0.1:10085"

--- a/roles/monitoring/tasks/xray_stats_exporter.yml
+++ b/roles/monitoring/tasks/xray_stats_exporter.yml
@@ -1,5 +1,61 @@
 ---
-- name: Copy xray-stats-exporter binary
+# Auto-download xray-stats-exporter from the GitHub release that matches
+# xray_stats_exporter_version (default "latest", or pinned "v1.0.2"). The
+# repo is public, so no token plumbing — anonymous get_url against the
+# release asset's browser_download_url is enough. delegate_to: localhost on
+# the API call avoids burning the prod host's small per-IP rate-limit.
+#
+# Override path: set xray_stats_exporter_local_binary=/path/to/binary at the
+# CLI (-e) or in inventory to skip the download and copy a hand-built binary
+# instead — used during the A2 deploy on 2026-05-02 before v1.0.2 was tagged
+# upstream, kept around for emergency rebuild scenarios.
+- name: xray-stats-exporter | Resolve release URL from GitHub API
+  ansible.builtin.uri:
+    url: >-
+      https://api.github.com/repos/{{ xray_stats_exporter_github_repo }}/releases/{{
+      'latest' if xray_stats_exporter_version == 'latest'
+      else 'tags/' ~ xray_stats_exporter_version }}
+    method: GET
+    return_content: true
+    headers:
+      Accept: "application/vnd.github.v3+json"
+    status_code: 200
+  register: _xray_stats_exporter_release_info
+  delegate_to: localhost
+  run_once: true
+  retries: 3
+  delay: 3
+  until: _xray_stats_exporter_release_info.status == 200
+  when: xray_stats_exporter_local_binary is not defined
+
+- name: xray-stats-exporter | Detect target architecture
+  ansible.builtin.set_fact:
+    _xray_stats_exporter_arch: >-
+      {{
+        'linux-amd64' if ansible_architecture in ['x86_64', 'amd64']
+        else 'linux-arm64' if ansible_architecture in ['aarch64', 'arm64']
+        else (undef() | mandatory(msg='unsupported arch ' ~ ansible_architecture))
+      }}
+  when: xray_stats_exporter_local_binary is not defined
+
+- name: xray-stats-exporter | Download binary
+  ansible.builtin.get_url:
+    url: >-
+      {{
+        (_xray_stats_exporter_release_info.json.assets
+          | selectattr('name', 'equalto', 'xray-stats-exporter-' ~ _xray_stats_exporter_arch)
+          | list | first
+        ).browser_download_url
+      }}
+    dest: "{{ xray_stats_exporter_bin_dir }}/xray-stats-exporter"
+    mode: "0755"
+    owner: root
+    group: root
+    force: true
+  notify: Restart xray-stats-exporter
+  when: xray_stats_exporter_local_binary is not defined
+
+- name: xray-stats-exporter | Copy local binary (override)
   ansible.builtin.copy:
     src: "{{ xray_stats_exporter_local_binary }}"
     dest: "{{ xray_stats_exporter_bin_dir }}/xray-stats-exporter"


### PR DESCRIPTION
## Summary

Removes the manual-binary-placement step the role currently requires. The
xray-stats-exporter binary on prod will now refresh from GitHub releases on
every \`role_monitoring\` run (or stay pinned via \`xray_stats_exporter_version\`).

Same pattern \`raven_dashboard\` already uses, but simpler because the
xray-stats-exporter repo is public — anonymous \`get_url\` against the
release asset's \`browser_download_url\`, no PAT plumbing.

## Why

During the A2 deploy on 2026-05-02 the new \`--anonymize-secret\` flag in the
systemd unit hit a stale v1.0.1 binary that had no idea about the flag, the
service crashed, and per-user metrics stopped emitting for ~35 minutes.
Root cause: the role had no way to bring the binary in sync with the
template. This PR closes that gap.

## ⚠️ Deployment order matters

**Do not merge + deploy this PR before xray-stats-exporter v1.0.2 ships.**
\`xray_stats_exporter_version: latest\` currently resolves to v1.0.1 which
crashes on \`--anonymize-secret\`. Sequence:

1. Merge AlchemyLink/xray-stats-exporter PR #3 (\`feat: --anonymize-secret\`)
2. Tag and push \`v1.0.2\` in that repo (release workflow uploads
   \`xray-stats-exporter-linux-amd64\` etc.)
3. Verify \`gh release view v1.0.2 --repo AlchemyLink/xray-stats-exporter\`
   shows the assets
4. Then merge this PR
5. Then \`ansible-playbook role_monitoring.yml ... --tags xray_stats_exporter\`

If you merge this PR before v1.0.2 lands, either pin
\`xray_stats_exporter_version: "v1.0.1"\` AND drop \`xray_stats_anonymize_secret\`
from the monitoring vault, or do not deploy until the tag is up.

## Defaults added
- \`xray_stats_exporter_github_repo: "AlchemyLink/xray-stats-exporter"\`
- \`xray_stats_exporter_version: "latest"\`

## Escape hatch preserved
\`-e xray_stats_exporter_local_binary=/path/to/binary\` still skips the
download and copies a hand-built drop — used during the 2026-05-02
emergency fix. Kept around for future "build and ship without releasing"
scenarios.

## Test plan
- [x] \`ansible-playbook --syntax-check role_monitoring.yml\` passes
- [ ] After v1.0.2 ships: \`ansible-playbook role_monitoring.yml --tags xray_stats_exporter\` (no \`-e local_binary\`) downloads + replaces the prod binary, exporter restarts cleanly with \`--anonymize-secret\` flag
- [ ] Smoke: dashboard \`/api/health\` workers still ok; \`curl http://127.0.0.1:9551/metrics | grep xray_user_uplink\` shows hashed labels