### PR TITLE
monitoring: derive nginx_exporter_listen from per-host wg_ip

### DIFF
--- a/roles/monitoring/defaults/main.yml
+++ b/roles/monitoring/defaults/main.yml
@@ -69,8 +69,10 @@ node_exporter_service_name: "node_exporter"
 
 # nginx-prometheus-exporter (RU only — reads nginx stub_status, exports request
 # count, accepts, connections by state; scraped by EU vmagent over WireGuard).
+# Listen on per-host WG IP so multi-RU works. Falls back to global wg_ru_ip
+# (10.10.0.2) for hosts without an explicit wg_ip — matches scrape.yml.j2 logic.
 nginx_exporter_version: "latest"
-nginx_exporter_listen: "10.10.0.2:9113"        # RU WG interface
+nginx_exporter_listen: "{{ hostvars[inventory_hostname].wg_ip | default(wg_ru_ip) }}:9113"
 nginx_exporter_bin_dir: "/usr/local/bin"
 nginx_stub_status_port: 8081                   # localhost-only nginx server block
 


### PR DESCRIPTION
## Why

`nginx_exporter_listen` defaulted to a hardcoded `10.10.0.2:9113` — the first RU's WG address. With multiple RUs in `groups['ru']` (live as of 2026-05-06), the second RU tried to bind to an address not assigned to its interface and entered a systemd restart loop:

```
HTTP server failed: listen tcp 10.10.0.2:9113: bind: cannot assign requested address
```

## Fix

Derive listen address from per-host `wg_ip` with the same `default(wg_ru_ip)` fallback that scrape configs and node_exporter already use:

```yaml
nginx_exporter_listen: "{{ hostvars[inventory_hostname].wg_ip | default(wg_ru_ip) }}:9113"
```

vmagent's `vmagent-scrape.yml.j2` already iterates `groups['ru']` with the same expression, so listening + scraping stay in lockstep on each RU.

## Behaviour

* `vm_my_ru` (wg_ip=10.10.0.2) → listen `10.10.0.2:9113` (unchanged)
* `vm_my_ru2` (wg_ip=10.10.0.3) → listen `10.10.0.3:9113` (was broken)
* future RUs auto-correct from their inventory entry.

## Test plan

- [x] Re-deployed on `vm_my_ru2`: service goes from `activating` (restart loop) to `active`, port binds, metrics return.
- [x] EU vmagent picks up new instance via existing `groups['ru']` loop, pushes to VictoriaMetrics.
- [x] VM query confirms `up{job="nginx-vm_my_ru2", instance="5.8.50.41"}` reports.
- [ ] Reviewer note: `vm_my_ru` continues to work because `wg_ip: 10.10.0.2` in inventory matches the previous hardcoded default — the new expression resolves to the same value for it.