### PR TITLE
srv_prepare: bump conntrack + SYN backlog for VPN workload

### DIFF
--- a/roles/srv_prepare/defaults/main.yml
+++ b/roles/srv_prepare/defaults/main.yml
@@ -41,8 +41,13 @@ srv_prepare_apps_list_alpine:
   - openssl
   - ca-certificates
 
-# Default sysctl settings
+# Default sysctl settings — TCP performance + conntrack capacity for VPN workload.
+# Default Ubuntu values are dangerously low for a multi-thousand-connection VPN
+# box: nf_conntrack_max=8192 fills under load, packets get silently dropped,
+# and tcp_timeout_established=432000 (5d) holds VPN slots forever even after
+# clients disconnect. Cause of "TLS handshake fails from new source IP" symptom.
 srv_prepare_bbr_settings:
+  # BBR + buffers
   net.ipv4.tcp_congestion_control: bbr        # Enable BBR
   net.core.default_qdisc: fq                  # Set default queue discipline to fq
   net.core.rmem_max: 67108864                 # Maximum receive buffer size
@@ -50,6 +55,13 @@ srv_prepare_bbr_settings:
   net.ipv4.tcp_rmem: 4096 87380 67108864      # Minimum, default, and maximum receive buffer sizes
   net.ipv4.tcp_wmem: 4096 65536 67108864      # Minimum, default, and maximum send buffer sizes
   net.core.netdev_max_backlog: 250000         # Maximum number of packets queued on the input side
-  net.core.somaxconn: 65535                   # Maximum number of connections that can be queued for acceptance
+  net.core.somaxconn: 65535                   # Maximum connection backlog
   net.ipv4.tcp_tw_reuse: 1                    # Allow reusing TIME-WAIT sockets for new connections
-  net.ipv4.tcp_fin_timeout: 15                # Reduce the time a socket stays in TIME-WAIT state
+  net.ipv4.tcp_fin_timeout: 15                # Reduce TIME-WAIT duration
+  # SYN backlog — protect bursty handshake bursts
+  net.ipv4.tcp_max_syn_backlog: 4096
+  # Conntrack capacity — VPN workload generates lots of short-lived flows
+  net.netfilter.nf_conntrack_max: 131072
+  net.netfilter.nf_conntrack_buckets: 131072
+  # Reduce VPN slot retention — 5 days default is too generous for short flows
+  net.netfilter.nf_conntrack_tcp_timeout_established: 3600


### PR DESCRIPTION
## Why

Default Ubuntu ships `nf_conntrack_max=8192` — adequate for a desktop, dangerously small for a VPN aggregation point. EU production was silently dropping packets:

```
$ dmesg | grep nf_conntrack
nf_conntrack: table full, dropping packet  (×many, recent)

$ cat /proc/net/stat/nf_conntrack | awk 'NR==2 {print "drops:" $11 " inserts_failed:" $9}'
drops: 55667    inserts_failed: 29371
```

Compounds with `tcp_timeout_established=432000` (5 days), which holds VPN slots even after clients disconnect.

Symptom: TLS handshakes from any source IP not already warm in the conntrack table fail intermittently. Discovered while bringing vm_my_ru2 online — new source IP, no warm entries, handshakes broke.

## Fix

Adds four entries to `srv_prepare_bbr_settings` (the dict the role already loops through):

```yaml
net.netfilter.nf_conntrack_max: 131072
net.netfilter.nf_conntrack_buckets: 131072
net.netfilter.nf_conntrack_tcp_timeout_established: 3600
net.ipv4.tcp_max_syn_backlog: 4096
```

Memory cost: ~50 MB on a 1vCPU/1GB box. Acceptable.

## Status

- Live patched on `vm_my_srv` via `sysctl -w` and `/etc/sysctl.d/99-vpn-tuning.conf` already (no waiting on this PR for relief).
- This PR is the codification — every future srv_prepare apply will write the same values into `/etc/sysctl.conf`, so a fresh box gets them too.
- All hosts in `groups['cloud']` and `groups['ru']` will receive the new values on next role apply.

## Test plan

- [x] YAML validates (`python3 -c "yaml.safe_load(open(..))"`)
- [x] `dmesg` no new conntrack-table-full entries since live patch (~30 min ago).
- [ ] Reviewer note: this does NOT close the separate "TLS handshake from vm_my_ru2 fails on 3/4 v2 Reality SNIs" issue. That bug has a different root cause — TCP-level connectivity is 100%, conntrack pressure is gone, but the handshake still stalls at TLS layer. Tracked separately; needs tcpdump investigation on EU :443.

Closes a latent capacity bug that would have hit any rapidly-growing user base with or without multi-RU.